### PR TITLE
Updated Deployment class to return id

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
     name='speedcurve.py',
     url='https://speedcurvepy.readthedocs.org',
     packages=packages,
-    version='0.1.3'
+    version='0.1.4'
 )

--- a/speedcurve/deployments.py
+++ b/speedcurve/deployments.py
@@ -13,4 +13,4 @@ class Deployment(SpeedCurveCore):
         self.detail = json.get('detail')
 
     def __repr__(self):
-        return '<Deployment [{}]>'.format(self.note)
+        return '<Deployment [{}]>'.format(self.id)

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -13,3 +13,6 @@ class TestDeployment(UnitHelper):
 
     def test_isinstance(self):
         assert isinstance(self.instance, Deployment)
+
+    def test_repr(self):
+        assert repr(self.instance).startswith('<Deployment')


### PR DESCRIPTION
The instance returned from `add_deploy` is missing many attributes so we want to use the `id`, which does get returned.