### PR TITLE
Fixed self.id for speedcurve.deployments.Deployment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
     name='speedcurve.py',
     url='https://speedcurvepy.readthedocs.org',
     packages=packages,
-    version='0.1.8'
+    version='0.1.9'
 )

--- a/speedcurve/deployments.py
+++ b/speedcurve/deployments.py
@@ -5,7 +5,7 @@ class Deployment(SpeedCurveCore):
     """Deployment class."""
 
     def _update_attributes(self, json):
-        self.id = json.get('id')
+        self.id = json.get('deploy_id')
         self.tests_completed = json.get('tests-completed')
         self.status = json.get('status')
         self.tests_remaining = json.get('tests-remaining')

--- a/tests/unit/example_data/deployment.json
+++ b/tests/unit/example_data/deployment.json
@@ -1,5 +1,6 @@
 {
-  "id": 10,
+  "deploy_id": 10,
+  "site_id": 123,
   "status": "completed",
   "tests-completed": [
     {

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -11,6 +11,22 @@ class TestDeployment(UnitHelper):
     described_class = Deployment
     example_data = get_example_data()
 
+    def test_id(self):
+        assert self.instance.id is not None
+
+    def test_attributes(self):
+        attributes = (
+            'id',
+            'tests_completed',
+            'status',
+            'tests_remaining',
+            'note',
+            'detail'
+        )
+
+        for attribute in attributes:
+            assert hasattr(self.instance, attribute)
+
     def test_isinstance(self):
         assert isinstance(self.instance, Deployment)
 


### PR DESCRIPTION
Previously, it was returning a None value.

```python
(Pdb) latest_deployment
<Deployment [None]>
```